### PR TITLE
Add support transactional emails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ ENV/
 
 # IDEA
 .idea/
+
+# Vim
+*.swp

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.2.2',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.2.3',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.2.2',
+    version='0.2.3',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -27,9 +27,7 @@ class EmailTests(TestCase):
         with self.assertRaises(Exception):
             self.event_client.send_email()
 
-    @mock.patch('zc_events.email.save_string_contents_to_s3')
-    @mock.patch('zc_events.client.EventClient.emit_microservice_email_notification')
-    def test_send_email(self, mock_emit_event, mock_save_string_contents_to_s3):
+    def _basic_email_test(self, mock_emit_event, mock_save_string_contents_to_s3):
         self.event_client.send_email(**self.send_email_kwargs)
 
         mock_emit_event.assert_called_once()
@@ -39,6 +37,33 @@ class EmailTests(TestCase):
             self.assertTrue(expected_arg in event_args)
 
         self.assertTrue(event_args['task_id'])
+
+        return event_args
+
+    @mock.patch('zc_events.email.save_string_contents_to_s3')
+    @mock.patch('zc_events.client.EventClient.emit_microservice_email_notification')
+    def test_send_email(self, mock_emit_event, mock_save_string_contents_to_s3):
+        self._basic_email_test(mock_emit_event, mock_save_string_contents_to_s3)
+
+    @mock.patch('zc_events.email.save_string_contents_to_s3')
+    @mock.patch('zc_events.client.EventClient.emit_microservice_email_notification')
+    def test_send_email_default_not_transactional(self, mock_emit_event, mock_save_string_contents_to_s3):
+        event_args = self._basic_email_test(mock_emit_event, mock_save_string_contents_to_s3)
+        self.assertFalse(event_args['is_transactional'])
+
+    @mock.patch('zc_events.email.save_string_contents_to_s3')
+    @mock.patch('zc_events.client.EventClient.emit_microservice_email_notification')
+    def test_send_email_that_is_transactional(self, mock_emit_event, mock_save_string_contents_to_s3):
+        self.send_email_kwargs['is_transactional'] = True
+        event_args = self._basic_email_test(mock_emit_event, mock_save_string_contents_to_s3)
+        self.assertTrue(event_args['is_transactional'])
+
+    @mock.patch('zc_events.email.save_string_contents_to_s3')
+    @mock.patch('zc_events.client.EventClient.emit_microservice_email_notification')
+    def test_send_email_that_is_not_transactional(self, mock_emit_event, mock_save_string_contents_to_s3):
+        self.send_email_kwargs['is_transactional'] = False
+        event_args = self._basic_email_test(mock_emit_event, mock_save_string_contents_to_s3)
+        self.assertFalse(event_args['is_transactional'])
 
     @mock.patch('zc_events.email.save_string_contents_to_s3')
     @mock.patch('zc_events.client.EventClient.emit_microservice_email_notification')

--- a/zc_events/email.py
+++ b/zc_events/email.py
@@ -22,7 +22,8 @@ def generate_s3_content_key(s3_folder_name, content_type, content_name=''):
 
 def generate_email_data(email_uuid, from_email=None, to=None, cc=None, bcc=None, reply_to=None, subject=None,
                         plaintext_body=None, html_body=None, headers=None, files=None, attachments=None,
-                        user_id=None, resource_type=None, resource_id=None, unsubscribe_group=None, **kwargs):
+                        user_id=None, resource_type=None, resource_id=None, unsubscribe_group=None,
+                        is_transactional=False, **kwargs):
     """
     files:       A list of file paths
     attachments: A list of tuples of the format (filename, content_type, content)
@@ -82,7 +83,8 @@ def generate_email_data(email_uuid, from_email=None, to=None, cc=None, bcc=None,
         'user_id': user_id,
         'resource_type': resource_type,
         'resource_id': resource_id,
-        'task_id': str(email_uuid)
+        'task_id': str(email_uuid),
+        'is_transactional': is_transactional
     }
 
     if unsubscribe_group:


### PR DESCRIPTION
Give the user of this library the ability to distinguish transactional
emails from normal emails that would fall under the CAN-SPAM Act. This
then allows the email provider to treat these emails differently as
well.

See the FTC's CAN-SPAM Act compliance guide for further information on
what a transactional email is, how it differs from normal emails a
business sends, and the rules are that they both must follow at
https://www.ftc.gov/tips-advice/business-center/guidance/can-spam-act-compliance-guide-business