### PR TITLE
Move request.encoding directly under object init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.3',
+    version='0.3.4',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.3',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.4',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[

--- a/zc_events/django_request.py
+++ b/zc_events/django_request.py
@@ -33,6 +33,10 @@ def create_django_request_object(roles, query_string, method, user_id=None, body
 
     request = HttpRequest()
 
+    # This is immediately after initializing request since setting the encoding
+    #   property will delete .GET from the object
+    request.encoding = 'utf-8'
+
     # For Django < 1.9
     request.GET = QueryDict(query_string)
 
@@ -42,7 +46,6 @@ def create_django_request_object(roles, query_string, method, user_id=None, body
     if body:
         request.read = lambda: ujson.dumps(body)
 
-    request.encoding = 'utf-8'
     request.method = method.upper()
     request.META = {
         'HTTP_AUTHORIZATION': 'JWT {}'.format(jwt_encode_handler(jwt_payload)),


### PR DESCRIPTION
The Django HttpRequest object's [encoding property setter](https://github.com/django/django/blob/1a34dfcf797640d5d580d261694cb54e6f97c552/django/http/request.py#L221) will delete the `GET` variable from the request object, causing an error to be thrown while handling an event.

Moving the line where we set the encoding up to be immediately after the request object initialization solves the issue.