### PR TITLE
Force client pika connection to recycle every 30s

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.6',
+    version='0.3.7',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.6',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[
@@ -35,8 +35,7 @@ setup(
         'boto3==1.4.7',
         'celery>=3.1.10,<4.0.0',
         'inflection>=0.3.1,<0.4',
-        'pika>=0.10.0,<0.11.0',
-        'pika_pool>=0.1.3,<0.1.4',
+        'pika>=0.10.0,<0.11.3',
         'redis>=2.10.5,<2.11.0',
         'ujson>=1.35,<1.36',
         'zc_common>=0.4.1',


### PR DESCRIPTION
This PR (hopefully) fixes an issue with nutrition where events were failing when emitting due to the pika connection being disconnected by RabbitMQ. The problem stems from the fact that RabbitMQ uses a heartbeat to determine whether a connection is still alive and the pika BlockingConnection we use is synchronous so it only communicates with the RabbitMQ server when emitting an event.

RabbitMQ has a heartbeat timeout of 60s (down from 580s before version 3.5.5), although CloudAMQP has a heartbeat timeout of 120s. 

```
=ERROR EVENT==== Fri, 29 Dec 2017 00:57:00 GMT ===
closing AMQP connection <0.15089.1155> (54.226.215.30:38693 -> 10.50.91.245:5672):
missed heartbeats from client, timeout: 120s
```

Most people who run into this problem have systems with long running tasks that take longer to process than the heartbeat timeout so that when a task finishes processing, RabbitMQ has already dropped the connection and can't accept the acknowledgement. Fewer people have the problem that we're running into where (as best as I can tell), we just don't emit enough events fast enough so the length of time between emitting events is greater than the timeout threshold.

At the cadence that we emit events, RabbitMQ has long since dropped our connection because the last time the server heard from us was minutes or hours prior. The event client tries to re-use that connection and fails as soon as it tries to select the channel after acquiring it.

There were several suggestions of how other people fixed this issue that I tried.

The first was to upgrade pika to the latest version and set the [heartbeat parameter](https://pika.readthedocs.io/en/latest/modules/parameters.html#pika.connection.ConnectionParameters.heartbeat) to 0 which turns heartbeats off. Some servers respect this setting from a client and don't disconnect them for missed heartbeats. Setting this didn't prevent the worker from timing out though.

Next I tried setting the [recycle parameter](https://github.com/bninja/pika-pool/blob/5b1d3b650395aed60d9995fbfd289de7e62fe8d5/pika_pool.py#L295) of pika pool to 30 which controls the lifetime of a connection before it gets recycled. We have it [set to 3600](https://github.com/ZeroCater/zc_events/blob/9f9840436fcd2154f0c50634f5e8c27e0b2ca91d/zc_events/client.py#L59), which is much larger than the 120s timeout we get from CloudAMQP which makes sense for why it'd be giving us a connection that has already timed out. Unfortunately setting it to 30 didn't seem to recycle the connection as it should although a quick look at the source code of pika_pool didn't seem to show any obvious reason for why that wasn't happening.

Another suggestion for getting around the timeout with a BlockingConnection is to have the client set the timeout to a really high value. Again, some servers respect this value when sent by the client, but this is more useful for the people who have jobs that take just longer than the heartbeat timeout. In our case I think we can go hours between emitting events, so even if we were able to bump it to some value higher than 120s it wouldn't make a difference.

Finally, pika does offer an asynchronous connection adapter called a [SelectConnection](https://pika.readthedocs.io/en/latest/modules/adapters/select.html), allowing you to register callback methods for various events such as on_open, on_close, etc. but this requires a fair amount more configuration and in reading through the documentation I wasn't entirely sure that this would fit the model of how we use the connection so we'd potentially have to change even more.

That left me looking for a different solution that would guarantee that we're getting a new connection before we time out. The first thing I did was remove pika_pool which I think is largely unnecessary for our use case and hasn't been updated in over a year and a half, but more importantly specifically has `pika<0.11` in its setup.py file, but pika has been on the 0.11+ release for over half a year now. It would probably still work with the new version of pika, but I'm all for dropping dependencies we don't use or need which I think is the case here.

The second thing I did was add a connection refresh with a default of 30s (in case CloudAMQP ever decides to drop 120s to the default 60s). That means the next message emitted more than 30s will be given a new connection, anything within that window will use the existing one. We do not explicitly call close on the old connection, but it will get dropped by RabbitMQ anyway due to the heartbeat timeout so we don't need to worry about orphaning connections on the server.

The downside to this is that there is, of course, some overhead related to opening a connection to RabbitMQ, and every 30 seconds might be too frequent. For our relatively low-traffic use-case I think this should be fine though (I went through one particularly frustrating part of this where I almost changed it so we open and close for each event...). 30 seconds should be sufficient to allow bursts but also never have any problems with trying to use a connection that has already been closed by the server but we don't know it yet.

I'm definitely open to other ways to solve this but hopefully the above provides enough context for how and why I landed at this solution.