### PR TITLE
Simplify zc_events, first stage.

### DIFF
--- a/Dockerfile-py2
+++ b/Dockerfile-py2
@@ -1,0 +1,10 @@
+FROM python:2
+ENV PYTHONUNBUFFERED 1
+RUN apt update
+RUN apt install entr --yes
+RUN mkdir /code
+WORKDIR /code
+ADD . /code/
+RUN pip install -r requirements-dev.txt
+# Remove django becaues celery checks if django is installed
+RUN pip uninstall --yes django

--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,0 +1,10 @@
+FROM python:3
+ENV PYTHONUNBUFFERED 1
+RUN apt update
+RUN apt install entr --yes
+RUN mkdir /code
+WORKDIR /code
+ADD . /code/
+RUN pip install -r requirements-dev.txt
+# Remove django becaues celery checks if django is installed
+RUN pip uninstall --yes django

--- a/README.md
+++ b/README.md
@@ -1,8 +1,66 @@
 # zc_events
 
-# Event Based Communication
+# Long term plan
 
-In order to send and receive marketplace events through RabbitMQ there is some configuration that needs to occur at the service level.
+The long term plan is to simplify this library as much as possible. This will be done in several stages:
+
+- [x] Add http verbs to `EventClient`
+- [x] Deprecate all other methods on `EventClient`, except `email` related ones.
+- [x] Decouple `EventClient` from any particular backend to send events.
+- [ ] Move over sending events through Django Rest Framework.
+- [ ] Move over sending specific `email` type of events.
+- [ ] Create a `celery` backend to stop placing things directly on rabbitmq, with sane defaults.
+- [ ] Major version change that removes deprecated methods and classes.
+
+Each of the above represent potential releases.
+
+## Vision
+
+This library should be as simple as possible, with a standard interface that is decoupled from the transport mechanism underlying any event system (RabbitMQ, Celery, Redis, HTTPS, etc.).
+
+## Example based goals
+
+```python
+# Server side
+def add(request):
+    data = request.data
+    return {
+        'answer': data['x'] + data['y']
+    }
+```
+
+### Fire and forget
+
+```python
+# Client side
+zc_events.post_no_wait('add', data={'x': 1, 'y': 1})
+```
+
+### Wait for a response
+
+```python
+# Client side
+response = zc_events.get('add', data={'x': 1, 'y': 1})
+response.data  # {'answer': 2}
+response.has_errors  # False
+```
+
+
+### Get errors
+
+```python
+# Client side
+response = zc_events.get('add', data={'x': 1})
+response.data  # None
+response.has_errors  # True
+response.errors  # [{ 'type': 'KeyError', 'message': 'y' }]
+```
+
+## Working Example
+
+A working example can be found in the `examples` folder, and can be run via `docker-compose run client3` and `docker-compose run client2`.
+
+# Installation
 
 ## Settings changes
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  services:
+    - redis
 dependencies:
   override:
     - pip install -r requirements-dev.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3'
+
+services:
+  redis:
+    image: redis:alpine
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - 8080:15672
+  worker3:
+    build:
+      context: .
+      dockerfile: Dockerfile-py3
+    volumes:
+      - .:/code
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - DJANGO_SETTINGS_MODULE=examples.settings
+      - ZC_EVENTS_SETTINGS=examples.settings
+      - C_FORCE_ROOT=1
+    depends_on:
+      - redis
+      - rabbitmq
+    command: bash -c "celery -A examples.worker_example worker --loglevel=info"
+  client3:
+    build:
+      context: .
+      dockerfile: Dockerfile-py3
+    volumes:
+      - .:/code
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - DJANGO_SETTINGS_MODULE=examples.settings
+      - ZC_EVENTS_SETTINGS=examples.settings
+      - C_FORCE_ROOT=1
+    depends_on:
+      - redis
+      - rabbitmq
+      - worker3
+    command: python3 examples/client_example.py
+  worker2:
+    build:
+      context: .
+      dockerfile: Dockerfile-py2
+    volumes:
+      - .:/code
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - DJANGO_SETTINGS_MODULE=examples.settings
+      - ZC_EVENTS_SETTINGS=examples.settings
+      - C_FORCE_ROOT=1
+    depends_on:
+      - redis
+      - rabbitmq
+    command: bash -c "celery -A examples.worker_example worker --loglevel=info"
+  client2:
+    build:
+      context: .
+      dockerfile: Dockerfile-py2
+    volumes:
+      - .:/code
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - DJANGO_SETTINGS_MODULE=examples.settings
+      - ZC_EVENTS_SETTINGS=examples.settings
+      - C_FORCE_ROOT=1
+    depends_on:
+      - redis
+      - rabbitmq
+      - worker2
+    command: python examples/client_example.py
+

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -1,0 +1,30 @@
+import time
+from zc_events.client import EventClient
+
+time.sleep(10)  # Allow rabbitmq/redis/worker to come up
+
+c = EventClient()
+
+assert c.call('add', data={'x': 1, 'y': 1}).data == 2
+assert c.get('add', data={'x': 1, 'y': 2}).data == 3
+assert c.put('add', data={'x': 1, 'y': 4}).data == 5
+assert c.post('add', data={'x': 21, 'y': 2}).data == 23
+assert c.delete('add', data={'x': 10, 'y': 20}).data == 30
+
+assert c.call_no_wait('add', data={'x': 1, 'y': 1}) is None
+assert c.put_no_wait('add', data={'x': 1, 'y': 2}) is None
+assert c.post_no_wait('add', data={'x': 1, 'y': 2}) is None
+assert c.delete_no_wait('add', data={'x': 1, 'y': 2}) is None
+
+bad_response = c.get('add', data={'x': 1})
+assert bad_response.has_errors is True
+assert 'trace' in bad_response.errors[0]
+# It returns a stack trace on error, but it's tough to match the exact string.
+del bad_response.errors[0]['trace']
+assert bad_response.errors == [{'type': 'KeyError', 'message': "'y'"}]
+assert bad_response.data is None
+
+good_response = c.get('add', data={'x': 1, 'y': 2})
+assert good_response.has_errors is False
+assert good_response.errors == []
+assert good_response.data == 3

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -1,0 +1,25 @@
+from kombu import Exchange, Queue
+from examples.worker_tasks import add
+from zc_events.backends import RabbitMqFanoutBackend
+
+AWS_ACCESS_KEY_ID = 'aws-access-key'
+AWS_SECRET_ACCESS_KEY = 'aws-secret-key'
+SECRET_KEY = 'test-secret-key'
+SERVICE_NAME = 'zc-events-test'
+BROKER_URL = 'amqp://guest:guest@rabbitmq:5672/%2F'
+EVENTS_REDIS_URL = 'redis://redis:6379'
+STAGING_NAME = 'test'
+EVENTS_EXCHANGE = 'test-exchange'
+NOTIFICATIONS_EXCHANGE = 'test-notification-exchange'
+
+events_exchange = Exchange(EVENTS_EXCHANGE, type='fanout')
+
+CELERY_QUEUES = (
+    # Add this line
+    Queue(SERVICE_NAME + '-events', events_exchange, queue_arguments={'x-max-priority': 10}, routing_key='#'),
+)
+
+CELERY_ROUTES = ('zc_events.routers.TaskRouter',)
+
+JOB_MAPPING = {'add': add}
+RPC_BACKEND = RabbitMqFanoutBackend()

--- a/examples/worker_example.py
+++ b/examples/worker_example.py
@@ -1,0 +1,16 @@
+from celery import Celery
+from zc_events.backends import dispatch_task
+from examples.settings import BROKER_URL, SERVICE_NAME, EVENTS_EXCHANGE
+
+
+app = Celery(
+    'tests.worker_example',
+    broker=BROKER_URL
+)
+
+app.config_from_object('examples.settings')
+
+
+@app.task(name='microservice.event')
+def listener(name, data):
+    return dispatch_task(name, data)

--- a/examples/worker_example.py
+++ b/examples/worker_example.py
@@ -1,5 +1,5 @@
 from celery import Celery
-from zc_events.backends import dispatch_task
+from zc_events.backends import rabbitmq_dispatch_task
 from examples.settings import BROKER_URL, SERVICE_NAME, EVENTS_EXCHANGE
 
 
@@ -13,4 +13,4 @@ app.config_from_object('examples.settings')
 
 @app.task(name='microservice.event')
 def listener(name, data):
-    return dispatch_task(name, data)
+    return rabbitmq_dispatch_task(name, data)

--- a/examples/worker_tasks.py
+++ b/examples/worker_tasks.py
@@ -1,0 +1,3 @@
+def add(request):
+    data = request.data
+    return data['x'] + data['y']

--- a/tests/backends/test_rabbitmqredis.py
+++ b/tests/backends/test_rabbitmqredis.py
@@ -1,0 +1,66 @@
+import pytest
+import uuid
+from zc_events.backends import rabbitmq_dispatch_task, RabbitMqFanoutBackend
+from zc_events.backends.rabbitmqredis import _get_response
+
+
+class TestDispatchingEvents:
+    """Test dispatching a request to the appropriate function and responding.
+
+    Dispatching happens on the server side.
+
+    Note:
+        This might be generic enough to test any other backend we implement, with some modification.
+    """
+
+    def _setup(self):
+        self.response_key = str(uuid.uuid4)
+        self.request_data = {
+            'response_key': self.response_key,
+            'id': '456',
+            'data': {
+                'x': 1, 'y': 2
+            }
+        }
+        self.redis_client = RabbitMqFanoutBackend()._redis_client
+        self.redis_client.flushdb()
+
+    def _get_response(self):
+        return _get_response(self.redis_client, self.response_key)
+
+    def test_valid_response(self):
+        self._setup()
+        responded, key_found = rabbitmq_dispatch_task('add', self.request_data)
+        response = self._get_response()
+        assert responded is True
+        assert key_found is True
+        assert response.data == 3
+        assert response.has_errors is False
+        assert response.errors == []
+
+    def test_exception_thrown(self):
+        self._setup()
+        del self.request_data['data']['y']
+        responded, key_found = rabbitmq_dispatch_task('add', self.request_data)
+        response = self._get_response()
+        assert responded is True
+        assert key_found is True
+        assert response.data is None
+        assert response.has_errors is True
+        assert 'trace' in response.errors[0]
+        # It returns a stack trace on error, but it's tough to match the exact string.
+        del response.errors[0]['trace']
+        assert response.errors == [{'type': 'KeyError', 'message': "'y'"}]
+
+    def test_no_response_key(self):
+        self._setup()
+        self.request_data['response_key'] = None
+        responded, key_found = rabbitmq_dispatch_task('add', self.request_data)
+        assert responded is False
+        assert key_found is True
+
+    def test_no_method_mapped(self):
+        self._setup()
+        responded, key_found = rabbitmq_dispatch_task('subtract', self.request_data)
+        assert responded is False
+        assert key_found is False

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,9 +1,22 @@
+from os import environ
+from zc_events.backends import RabbitMqFanoutBackend
+
 AWS_ACCESS_KEY_ID = 'aws-access-key'
 AWS_SECRET_ACCESS_KEY = 'aws-secret-key'
 SECRET_KEY = 'test-secret-key'
 SERVICE_NAME = 'zc-events-test'
 BROKER_URL = 'amqp://guest:guest@rabbitmq:5672/%2F'
-EVENTS_REDIS_URL = 'redis://redis:6379'
+EVENTS_REDIS_URL = environ.get('REDIS_URL', 'redis://redis:6379')
 STAGING_NAME = 'test'
 EVENTS_EXCHANGE = 'test-exchange'
 NOTIFICATIONS_EXCHANGE = 'test-notification-exchange'
+
+
+# Used as the remote function to call during tests
+def add(request):
+    data = request.data
+    return data['x'] + data['y']
+
+
+RPC_BACKEND = RabbitMqFanoutBackend()
+JOB_MAPPING = {'add': add}

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,6 @@ envlist = py27,py36
 [testenv]
 deps = -rrequirements-dev.txt
 commands=pytest --ds=tests.settings
+passenv=
+  REDIS_URL
+  CI

--- a/zc_events/__init__.py
+++ b/zc_events/__init__.py
@@ -1,4 +1,9 @@
+import logging
 from .client import EventClient
+
+# See the python docs for why
+# https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'EventClient'

--- a/zc_events/aws.py
+++ b/zc_events/aws.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 
 from six import reraise as raise_
 
-from django.conf import settings
+from zc_events.config import settings
 
 
 class S3IOException(Exception):

--- a/zc_events/backends.py
+++ b/zc_events/backends.py
@@ -1,0 +1,285 @@
+import logging
+import ujson as json
+import pika
+import pika_pool as pika_pool_lib
+import redis
+import traceback
+from zc_events.config import settings
+from zc_events.request import Request
+from zc_events.responses import Response
+from zc_events.exceptions import RequestTimeout
+
+_DEFAULT_ROUTING_KEY = ''
+_LOW_PRIORITY = 0
+_HIGH_PRIORITY = 9
+
+
+logger = logging.getLogger(__name__)
+
+
+def _noop(request):
+    pass
+
+
+def _format_exception_response(exception_name, exception_msg, exception_trace):
+    return {
+        'data': None,
+        'has_errors': True,
+        'errors': [
+            {
+                'type': exception_name,
+                'message': exception_msg,
+                'trace': exception_trace
+            }
+        ]
+    }
+
+
+def dispatch_task(name, data):
+    """Dispatch the task for processing on the server side.
+
+    Example:
+        @app.task('microservice.event')
+        def listener(event_name, data):
+            from zc_events.backends import dispatch_task
+            return dispatch_task(event_name, data)
+
+
+    Note:
+        This function relies up `JOB_MAPPING` to be defined in your settings,
+        which is a dict with the key corresponding to a name and the value being
+        a function which will accept an `Request` paramater. If no name is found,
+        nothing happens with the request.
+
+        This function also needs the `RPC_BACKEND` setting to be instantiated
+        so it can use the `respond` method.
+
+    Args:
+        name (str): The name of the function to be called.
+        data (dict or None): The data to be used to populate the Request object.
+    """
+    logger.info('zc_events received name={name} data={data}'.format(name=name, data=data))
+    request = Request(data)
+    func = settings.JOB_MAPPING.get(name, _noop)
+    try:
+        response = {
+            'data': func(request),
+            'has_errors': False,
+            'errors': []
+        }
+    except Exception as e:
+        msg = str(e)
+        ex_type = e.__class__.__name__
+        trace = traceback.format_exc()
+        logger.exception(
+            'zc_events dispatched func threw an exception: name={name} data={data} '
+            'exception={ex} message={msg} trace={trace}'.format(
+                name=name,
+                data=data,
+                ex=ex_type,
+                msg=msg,
+                trace=trace
+            )
+        )
+        response = _format_exception_response(ex_type, msg, trace)
+    backend = settings.RPC_BACKEND
+    logger.info('zc_events finished name={name} data={data} response={response}'.format(
+        name=name, data=data, response=response))
+    backend.respond(request.response_key, response)
+
+
+def _get_raw_response(redis_client, response_key):
+    try:
+        key_and_response = redis_client.blpop(response_key, 30)
+        if key_and_response is None:
+            raise RequestTimeout(detail='Timed out waiting for redis response')
+
+        response = key_and_response[1]  # Index [0] is the response_key
+        logger.debug('zc_events got response response_key={response_key} response={response}'.format(
+            response_key=response_key,
+            response=response
+        ))
+    except Exception as e:
+        msg = str(e)
+        ex_type = e.__class__.__name__
+        trace = traceback.format_exc()
+        logger.exception(
+            'zc_events exception waiting for response response_key={response_key} '
+            'exception={ex} message={msg} trace={trace}'.format(
+                response_key=response_key,
+                ex=ex_type,
+                msg=msg,
+                trace=trace
+            )
+        )
+        response = json.dumps(_format_exception_response(ex_type, msg, trace))
+    return response
+
+
+def _respond(redis_client, response_key, data):
+    result = redis_client.rpush(response_key, json.dumps(data))
+    redis_client.expire(response_key, 60)
+    return result
+
+
+def _place_on_queue(pika_pool, events_exchange, routing_key, priority, event_body):
+    event_queue_name = '{}-events'.format(settings.SERVICE_NAME)
+    queue_arguments = {
+        'x-max-priority': 10
+    }
+    response = None
+    logger.debug(
+        'zc_events placing on queue with the following '
+        'events_exchange={events_exchange} routing_key={routing_key} '
+        'event_body={event_body} priority={priority}'.format(
+           events_exchange=events_exchange, routing_key=routing_key, event_body=event_body, priority=priority
+        )
+    )
+    with pika_pool.acquire() as cxn:
+        cxn.channel.queue_declare(queue=event_queue_name, durable=True, arguments=queue_arguments)
+        response = cxn.channel.basic_publish(
+            events_exchange,
+            routing_key,
+            event_body,
+            pika.BasicProperties(
+                content_type='application/json',
+                content_encoding='utf-8',
+                priority=priority
+            )
+        )
+
+    if not response:
+        raise EmitEventException("Message may have failed to deliver")
+    return response
+
+
+def _format_data(data, method, key):
+    data['_backend'] = {
+        'type': 'rabbitmqfanout',
+        'method': method,
+        'key': key
+    }
+    return {
+        'task': 'microservice.event',
+        'id': data['id'],
+        'args': [key, data],
+        'response_key': data['response_key']
+    }
+
+
+class RabbitMqFanoutBackend:
+    """A backend implementation using Rabbitmq fanout strategy and redis for responses.
+
+    The intent for this backend is to use a Rabbitmq fanout strategy, with redis for responding quickly.
+    It is also required that the consumers of the events on Rabbitmq be using celery 3 or 4.
+
+    Note:
+        It is not intended to be used directly by developers, but instead set and instantiated
+        through the RPC_BACKEND setting.
+
+        All public methods are backend implementations for the corresponding methods on EventClient,
+        except for the respond method.
+
+    Args:
+        redis_client (redis connection, (optional)): If this option is not provided, a redis connection
+            is gotten by using the EVENTS_REDIS_URL in your settings, using db 0.
+        pick_pool(pika_pool.QueuedPool, (optional)): The connection used by rabbitmq. If it is not provided,
+            a connection is established using the BROKER_URL from settings.
+    """
+
+    def __init__(self, redis_client=None, pika_pool=None):
+        if redis_client:
+            self._redis_client = redis_client
+        else:
+            pool = redis.ConnectionPool().from_url(settings.EVENTS_REDIS_URL, db=0)
+            self._redis_client = redis.Redis(connection_pool=pool)
+
+        if pika_pool:
+            self._pika_pool = pika_pool
+        else:
+            pika_params = pika.URLParameters(settings.BROKER_URL)
+            pika_params.socket_timeout = 5
+            self._pika_pool = pika_pool_lib.QueuedPool(
+                create=lambda: pika.BlockingConnection(parameters=pika_params),
+                max_size=10,
+                max_overflow=10,
+                timeout=10,
+                recycle=3600,
+                stale=45,
+            )
+
+        self._events_exchange = settings.EVENTS_EXCHANGE
+
+    def call(self, key, data):
+        return self.post(key, data)
+
+    def call_no_wait(self, key, data):
+        return self.post_no_wait(key, data)
+
+    def get(self, key, data):
+        data = _format_data(data, 'GET', key)
+        return self._enqueue_with_waiting(data)
+
+    def put(self, key, data):
+        data = _format_data(data, 'PUT', key)
+        return self._enqueue_with_waiting(data)
+
+    def put_no_wait(self, key, data):
+        data = _format_data(data, 'PUT', key)
+        return self._enqueue_without_waiting(data)
+
+    def post(self, key, data):
+        data = _format_data(data, 'POST', key)
+        return self._enqueue_with_waiting(data)
+
+    def post_no_wait(self, key, data):
+        data = _format_data(data, 'POST', key)
+        return self._enqueue_without_waiting(data)
+
+    def delete(self, key, data):
+        data = _format_data(data, 'DELETE', key)
+        return self._enqueue_with_waiting(data)
+
+    def delete_no_wait(self, key, data):
+        data = _format_data(data, 'DELETE', key)
+        return self._enqueue_without_waiting(data)
+
+    def _enqueue_without_waiting(self, data):
+        _place_on_queue(
+            self._pika_pool,
+            self._events_exchange,
+            _DEFAULT_ROUTING_KEY,
+            _LOW_PRIORITY,
+            json.dumps(data)
+        )
+
+    def _enqueue_with_waiting(self, data):
+        _place_on_queue(
+            self._pika_pool,
+            self._events_exchange,
+            _DEFAULT_ROUTING_KEY,
+            _HIGH_PRIORITY,
+            json.dumps(data)
+        )
+        response = _get_raw_response(self._redis_client, data['response_key'])
+        json_response = json.loads(response)
+        return Response(json_response)
+
+    def respond(self, response_key, data):
+        """
+        Respond to a request with the results.
+
+        Args:
+            response_key (str or None): If the response key is empty no response is done.
+            data (dict): The fully formatted response to be sent to the client and passed to the Response object.
+
+        Returns
+            bool: True if responded, False if it did not.
+        """
+        logger.debug('zc_events responding with response_key={response_key} data={data}'.format(
+            response_key=response_key, data=data
+        ))
+        if response_key:
+            _respond(self._redis_client, response_key, data)
+            return True
+        return False

--- a/zc_events/backends/__init__.py
+++ b/zc_events/backends/__init__.py
@@ -1,0 +1,2 @@
+from zc_events.backends.rabbitmqredis import RabbitMqFanoutBackend
+from zc_events.backends.rabbitmqredis import dispatch_task as rabbitmq_dispatch_task

--- a/zc_events/backends/rabbitmqredis.py
+++ b/zc_events/backends/rabbitmqredis.py
@@ -173,7 +173,7 @@ def _format_data(data, method, key):
     }
 
 
-class RabbitMqFanoutBackend:
+class RabbitMqFanoutBackend(object):
     """A backend implementation using Rabbitmq fanout strategy and redis for responses.
 
     The intent for this backend is to use a Rabbitmq fanout strategy, with redis for responding quickly.

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -9,16 +9,16 @@ from six.moves import urllib
 import pika
 import pika_pool
 import redis
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from zc_events.config import settings
 from inflection import underscore
 
 from zc_events.aws import save_string_contents_to_s3
 from zc_events.django_request import structure_response, create_django_request_object
 from zc_events.email import generate_email_data
 from zc_events.event import ResourceRequestEvent
-from zc_events.exceptions import EmitEventException
+from zc_events.exceptions import EmitEventException, ImproperlyConfigured
 from zc_events.utils import notification_event_payload
+from zc_events.backends import RabbitMqFanoutBackend
 
 SERVICE_ACTOR = 'service'
 ANONYMOUS_ACTOR = 'anonymous'
@@ -27,6 +27,21 @@ SERVICE_ROLES = [SERVICE_ACTOR]
 ANONYMOUS_ROLES = [ANONYMOUS_ACTOR]
 
 logger = logging.getLogger('django')
+
+_DEPRECATE_MESSAGE = "DEPRECATION WARNING: Use one of the HTTP verb methods instead"
+
+
+def _deprecated():
+    logger.warning(_DEPRECATE_MESSAGE)
+
+
+def _format_data_structure(data, headers, response_key=False):
+    return {
+        'data': data,
+        'id': str(uuid.uuid4()),
+        'headers': headers,
+        'response_key': str(uuid.uuid4()) if response_key else None
+    }
 
 
 class MethodNotAllowed(Exception):
@@ -44,6 +59,15 @@ class MethodNotAllowed(Exception):
 
 
 class EventClient(object):
+    """Used on the client side to send rpc-style events.
+
+    Non-deprecated methods are backend agnostic, and documented.
+
+    Note:
+        This is in a state of being upgraded, and is not totally backend agnostic yet.
+        In the next major release it will be backend agnostic, and will be removing many of the public methods,
+        but first we are providing the new methods in a back-wards compatible way.
+    """
 
     def __init__(self):
         pool = redis.ConnectionPool().from_url(settings.EVENTS_REDIS_URL, db=0)
@@ -62,8 +86,154 @@ class EventClient(object):
 
         self.events_exchange = settings.EVENTS_EXCHANGE
         self.notifications_exchange = getattr(settings, 'NOTIFICATIONS_EXCHANGE', None)
+        self._backend = RabbitMqFanoutBackend(
+            redis_client=self.redis_client,
+            pika_pool=self.pika_pool
+        )
+
+    def _format_and_make_call(self, key, data, headers, response_key, method):
+        formatted_data = _format_data_structure(data, headers, response_key)
+        return getattr(self._backend, method)(key, formatted_data)
+
+    def call(self, key, data={}, headers={}):
+        """Call a function in rpc-style a way and wait for the response.
+
+        This is a thing wrapper around `post`, and is provided to make code readable in situations
+        where the name `call` may make more sense.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            Response: An object containing the response from the remove function.
+        """
+        return self.post(key, data=data, headers=headers)
+
+    def call_no_wait(self, key, data={}, headers={}):
+        """Call a function in rpc-style a way, without waiting for any response.
+
+        This is a thing wrapper around `post_no_wait`, and is provided to make code readable in situations
+        where the name `call` may make more sense.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            None
+        """
+        return self.post_no_wait(key, data=data, headers=headers)
+
+    def get(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a GET http request, and wait for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            Response: An object containing the response from the remove function.
+        """
+        return self._format_and_make_call(
+            key, data, headers, True, 'get'
+        )
+
+    def put(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a PUT http request, and wait for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            Response: An object containing the response from the remove function.
+        """
+        return self._format_and_make_call(
+            key, data, headers, True, 'put'
+        )
+
+    def put_no_wait(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a PUT http request, without waiting for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            None
+        """
+        return self._format_and_make_call(
+            key, data, headers, False, 'put_no_wait'
+        )
+
+    def post(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a POST http request, and wait for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            Response: An object containing the response from the remove function.
+        """
+        return self._format_and_make_call(
+            key, data, headers, True, 'post'
+        )
+
+    def post_no_wait(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a POST http request, without waiting for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            None
+        """
+        return self._format_and_make_call(
+            key, data, headers, False, 'post_no_wait'
+        )
+
+    def delete(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a DELETE http request, and wait for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            Response: An object containing the response from the remove function.
+        """
+        return self._format_and_make_call(
+            key, data, headers, True, 'delete'
+        )
+
+    def delete_no_wait(self, key, data={}, headers={}):
+        """Call a remote function in an analogous fashion to a DELETE http request, without waiting for a response.
+
+        Args:
+            key (str): The key used to lookup the function to be called.
+            data (dict, optional): The data to be sent to the remote function.
+            headers (dict, optional): Optional, http style, information to be sent to the remote function.
+
+        Returns:
+            None
+        """
+        return self._format_and_make_call(
+            key, data, headers, False, 'delete_no_wait'
+        )
 
     def emit_microservice_message(self, exchange, routing_key, event_type, priority=0, *args, **kwargs):
+        _deprecated()
         task_id = str(uuid.uuid4())
 
         keyword_args = {'task_id': task_id}
@@ -111,6 +281,7 @@ class EventClient(object):
         return response
 
     def emit_microservice_event(self, event_type, *args, **kwargs):
+        _deprecated()
         return self.emit_microservice_message(self.events_exchange, '', event_type, *args, **kwargs)
 
     def emit_microservice_email_notification(self, event_type, *args, **kwargs):

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -98,7 +98,7 @@ class EventClient(object):
     def call(self, key, data={}, headers={}):
         """Call a function in rpc-style a way and wait for the response.
 
-        This is a thing wrapper around `post`, and is provided to make code readable in situations
+        This is a thin wrapper around `post`, and is provided to make code readable in situations
         where the name `call` may make more sense.
 
         Args:
@@ -114,8 +114,8 @@ class EventClient(object):
     def call_no_wait(self, key, data={}, headers={}):
         """Call a function in rpc-style a way, without waiting for any response.
 
-        This is a thing wrapper around `post_no_wait`, and is provided to make code readable in situations
-        where the name `call` may make more sense.
+        This is a thin wrapper around `post_no_wait`, and is provided to make code readable in situations
+        where the name `call_no_wait` may make more sense.
 
         Args:
             key (str): The key used to lookup the function to be called.

--- a/zc_events/config.py
+++ b/zc_events/config.py
@@ -1,0 +1,64 @@
+"""How zc_events retrieves and gets settings.
+
+This is a lazily evaluated settings module that first tries to read
+from django settings, but if it is not available, reads from whatever
+file is imported via the `ZC_EVENTS_SETTINGS` environment variable.
+
+Example:
+    export ZC_EVENTS_SETTINGS=some.settings
+
+    In this example, their is a python module called `some` with a file called
+    `settings.py` which the settings will be loaded from.
+"""
+import logging
+import importlib
+import os
+import uuid
+try:
+    from django.conf import settings as django_settings
+except:
+    django_settings = None
+
+_DOES_NOT_EXIST = str(uuid.uuid4())
+
+logger = logging.getLogger(__name__)
+
+
+class _LazySettings:
+    """A lazy way to retrieve settings.
+
+    This class makes it possible to import settings, but they are not evaluated until they are needed.
+
+    Note:
+        If django is installed, it uses django's settings. If not, the it gets the settings from
+        whatever file is imported from the `ZC_EVENTS_SETTINGS` env. variable.
+    """
+
+    def __init__(self):
+        self._settings = None
+
+    def __getattr__(self, name):
+        if not self._settings:
+            if django_settings:
+                logger.debug('zc_events is using django settings')
+                self._settings = django_settings
+            else:
+                logger.debug('zc_events could not use django settings, using ZC_EVENTS_SETTINGS')
+                import_path = os.environ.get('ZC_EVENTS_SETTINGS')
+                try:
+                    self._settings = importlib.import_module(import_path)
+                except Exception as e:
+                    logger.exception(
+                        'zc_events could not import settings. '
+                        'Did you forget to set ZC_EVENTS_SETTINGS? path={import_path}'.format(
+                            import_path=import_path
+                        )
+                    )
+                    raise e
+        value = getattr(self._settings, name, _DOES_NOT_EXIST)
+        if value == _DOES_NOT_EXIST:
+            raise AttributeError()
+        return value
+
+
+settings = _LazySettings()

--- a/zc_events/config.py
+++ b/zc_events/config.py
@@ -16,10 +16,9 @@ import os
 import uuid
 try:
     from django.conf import settings as django_settings
-except:
+except ImportError:
     django_settings = None
 
-_DOES_NOT_EXIST = str(uuid.uuid4())
 
 logger = logging.getLogger(__name__)
 
@@ -55,10 +54,10 @@ class _LazySettings:
                         )
                     )
                     raise e
-        value = getattr(self._settings, name, _DOES_NOT_EXIST)
-        if value == _DOES_NOT_EXIST:
-            raise AttributeError()
-        return value
+        if hasattr(self._settings, name):
+            return getattr(self._settings, name)
+        else:
+            raise AttributeError('zc_events could not find {name} in settings.'.format(name=name))
 
 
 settings = _LazySettings()

--- a/zc_events/django_request.py
+++ b/zc_events/django_request.py
@@ -1,13 +1,6 @@
 import ujson
 import zlib
 
-try:
-    from zc_common.jwt_auth.utils import jwt_encode_handler
-except ImportError:
-    pass
-
-from django.http import HttpRequest, QueryDict
-
 
 def structure_response(status, data):
     """
@@ -24,6 +17,8 @@ def create_django_request_object(roles, query_string, method, user_id=None, body
     Create a Django HTTPRequest object with the appropriate attributes pulled
     from the event.
     """
+    from django.http import HttpRequest, QueryDict
+    from zc_common.jwt_auth.utils import jwt_encode_handler
     if not http_host:
         http_host = 'local.zerocater.com'
 

--- a/zc_events/exceptions.py
+++ b/zc_events/exceptions.py
@@ -1,3 +1,10 @@
+try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:
+    class ImproperlyConfigured(Exception):
+        pass
+
+
 class RequestTimeout(Exception):
     status_code = 408
     default_detail = 'Request timed out.'

--- a/zc_events/request.py
+++ b/zc_events/request.py
@@ -92,3 +92,16 @@ class RemoteResourceListWrapper(list):
 
     def add_items_from_data(self, included):
         [self.append(RemoteResourceWrapper(x, included)) for x in self.data]
+
+
+class Request:
+    """Represents a request to the method handling the call.
+
+    Attributes:
+        data (dict or None): The data being transmitted by the client.
+        response_key (str or None): The response key used to make sure the client receives the response.
+        id (str): An automatically generated unique request id.
+    """
+    def __init__(self, request):
+        for key, value in request.items():
+            setattr(self, key, value)

--- a/zc_events/request.py
+++ b/zc_events/request.py
@@ -94,7 +94,7 @@ class RemoteResourceListWrapper(list):
         [self.append(RemoteResourceWrapper(x, included)) for x in self.data]
 
 
-class Request:
+class Request(object):
     """Represents a request to the method handling the call.
 
     Attributes:

--- a/zc_events/responses.py
+++ b/zc_events/responses.py
@@ -24,6 +24,35 @@ def wrapper%(signature)s:
 """
 
 
+class Response:
+    """Represents a response from an event, inspired by the requests library.
+
+    When the client performs an action that generates a response, that response
+    is represented by this class.
+
+    Example:
+    ```
+    r = client.get('add', data={'x': 1, 'y': 2})
+    assert r.has_errors is False
+    assert r.data == 3
+    assert r.errors == []
+
+    r = client.get('add', data={'x': 1})
+    assert r.has_errors is True
+    assert r.data is None
+    assert r.errors = .errors == [{'type': 'KeyError', 'message': "'y'"}]
+    ```
+
+    Attributes:
+        data (dict, object or None): The data returned by call, if no errors occur.
+        has_errors (bool): If an error was captured, it is set to True.
+        errors (list of dicts): Holds the errors that were thrown, if any.
+    """
+    def __init__(self, response):
+        for key, value in response.items():
+            setattr(self, key, value)
+
+
 def get_wrapped(func, wrapper_template, evaldict):
     # Preserve the argspec for the wrapped function so that testing
     # tools such as pytest can continue to use their fixture injection.

--- a/zc_events/responses.py
+++ b/zc_events/responses.py
@@ -24,7 +24,7 @@ def wrapper%(signature)s:
 """
 
 
-class Response:
+class Response(object):
     """Represents a response from an event, inspired by the requests library.
 
     When the client performs an action that generates a response, that response

--- a/zc_events/routers.py
+++ b/zc_events/routers.py
@@ -1,5 +1,5 @@
 import re
-from django.conf import settings
+from zc_events.config import settings
 
 
 class TaskRouter(object):

--- a/zc_events/tests.py
+++ b/zc_events/tests.py
@@ -3,7 +3,7 @@ from __future__ import division
 import ujson
 import math
 
-from django.conf import settings
+from zc_events.config import settings
 
 from zc_events.utils import notification_event_payload
 


### PR DESCRIPTION
This first pull request to simplify zc_events:

- adds a http verb style interface to `EventClient`
- adds a standard dispatcher for the server side.
- moves to decouple the transport method from the client.
- allows for a standard response type to be returned.
- allows for a standard request type to be consumed.
- adds a working example
- updates the readme

It is the goal of this commit/pull request to maintain backwards
compatiblity until we are ready for a new major version. This is why
some code is duplicated at this time.

The [working example](https://github.com/ZeroCater/zc_events/pull/46/files#diff-35edba42b7e9a4d758a4b0a9f674302e) is the most illustrative way of seeing this in action.