### PR TITLE
0.3.7-rc2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.7-rc1',
+    version='0.3.7-rc2',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc1',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc2',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[

--- a/zc_events/config.py
+++ b/zc_events/config.py
@@ -39,13 +39,13 @@ class _LazySettings(object):
         if not self._settings:
             import_path = os.environ.get('ZC_EVENTS_SETTINGS')
             if import_path:
-                logger.debug('zc_events could not use django settings, using ZC_EVENTS_SETTINGS')
+                logger.debug('zc_events is using ZC_EVENTS_SETTINGS path={path}'.format(path=import_path))
                 try:
                     self._settings = importlib.import_module(import_path)
-                except Exception as e:
+                except ImportError as e:
                     logger.exception(
                         'zc_events could not import settings. '
-                        'Did you forget to set ZC_EVENTS_SETTINGS? path={import_path}'.format(
+                        'The path was not valid. path={import_path}'.format(
                             import_path=import_path
                         )
                     )
@@ -53,6 +53,8 @@ class _LazySettings(object):
             elif django_settings:
                 logger.debug('zc_events is using django settings')
                 self._settings = django_settings
+            else:
+                raise RuntimeError('zc_events could not find valid settings. Please set ZC_EVENTS_SETTINGS')
         if hasattr(self._settings, name):
             return getattr(self._settings, name)
         else:

--- a/zc_events/config.py
+++ b/zc_events/config.py
@@ -23,14 +23,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-class _LazySettings:
+class _LazySettings(object):
     """A lazy way to retrieve settings.
 
     This class makes it possible to import settings, but they are not evaluated until they are needed.
 
     Note:
-        If django is installed, it uses django's settings. If not, the it gets the settings from
-        whatever file is imported from the `ZC_EVENTS_SETTINGS` env. variable.
+        If `ZC_EVENTS_SETTINGS` is set then it uses that, if not it will try to use django's settings.
     """
 
     def __init__(self):
@@ -38,12 +37,9 @@ class _LazySettings:
 
     def __getattr__(self, name):
         if not self._settings:
-            if django_settings:
-                logger.debug('zc_events is using django settings')
-                self._settings = django_settings
-            else:
+            import_path = os.environ.get('ZC_EVENTS_SETTINGS')
+            if import_path:
                 logger.debug('zc_events could not use django settings, using ZC_EVENTS_SETTINGS')
-                import_path = os.environ.get('ZC_EVENTS_SETTINGS')
                 try:
                     self._settings = importlib.import_module(import_path)
                 except Exception as e:
@@ -54,6 +50,9 @@ class _LazySettings:
                         )
                     )
                     raise e
+            elif django_settings:
+                logger.debug('zc_events is using django settings')
+                self._settings = django_settings
         if hasattr(self._settings, name):
             return getattr(self._settings, name)
         else:


### PR DESCRIPTION
This does a couple of things:

1. Makes it so the environment variable `ZC_EVENTS_SETTINGS` is used first, and django settings is the backup. This was done because `JOB_MAPPING` requires you to import the actual task to run, and that might import a part of the django code that is not ready yet -- leading to an app configuration error.

2. Lazy evaluation of redis and rabbitmq connections so it only happens when needed. These read off settings which may not be available yet, leading to errors.

3. Updates setup.py file for 0.3.7-rc2.