### PR TITLE
Fix bug in determining job mappings.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,5 +99,6 @@ services:
       - redis
       - rabbitmq
       - worker2
+      - django_worker2
     command: python examples/client_example.py
 

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -66,3 +66,8 @@ assert wrapped.id == '-1'
 assert wrapped.answer == 3
 assert wrapped.method == 'POST'
 assert wrapped.type == 'AddView'
+
+# Demonstrate how to work with query strings in a GET type of request to APIView
+assert c.get('lookup_drf', headers={'query_string': 'x=1'}).data == {'data': 'y'}
+# Do the same, but expect an error response from the server
+assert c.get('lookup_drf', headers={'query_string': 'y=1'}).has_errors

--- a/examples/django/example/views.py
+++ b/examples/django/example/views.py
@@ -1,4 +1,5 @@
-from rest_framework import serializers
+from rest_framework import serializers, status
+from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 
@@ -45,3 +46,12 @@ class AddView(ViewSet):
 
     def destroy(self, request, pk=None):
         return self._add(request, pk=pk)
+
+
+class LookupView(APIView):
+
+    def get(self, request):
+        x = request.query_params.get('x')
+        return_value = 'y' if x else x
+        return_status = status.HTTP_200_OK if x else status.HTTP_400_BAD_REQUEST
+        return Response(return_value, status=return_status)

--- a/examples/django/example/zc_events_settings.py
+++ b/examples/django/example/zc_events_settings.py
@@ -1,9 +1,10 @@
 from zc_events.backends import RabbitMqFanoutBackend
-from example.views import AddView
+from example.views import AddView, LookupView
 from example.settings import *
 
 
 JOB_MAPPING = {
-    'add_drf': AddView
+    'add_drf': AddView,
+    'lookup_drf': LookupView
 }
 RPC_BACKEND = RabbitMqFanoutBackend()

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.7-rc3',
+    version='0.3.7-rc4',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc3',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc4',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[

--- a/zc_events/backends/rabbitmqredis/server.py
+++ b/zc_events/backends/rabbitmqredis/server.py
@@ -1,11 +1,17 @@
 import logging
 import ujson as json
 import traceback
+import six
 from zc_events.config import settings
 from zc_events.request import Request
 from zc_events.exceptions import RequestTimeout
 from zc_events.backends.rabbitmqredis.common import format_exception_response
 from zc_events.backends.rabbitmqredis import viewset_handler
+
+if six.PY2:
+    from collections import Mapping
+else:
+    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +41,7 @@ def _handle_regular_func(func, data):
 
 def _get_job_info(name):
     val = settings.JOB_MAPPING.get(name)
-    if hasattr(val, 'get'):
+    if isinstance(val, Mapping):
         return val.get('func'), val.get('relationship_viewset')
     return val, None
 


### PR DESCRIPTION
Fixes #52

Fix the bug in determining job mappings by doing a collection check
instead of just an `hasattr` check. In addition, provide an example of
how to work with `query_params` in an APIView.

Finally, add the python 2 django worker to the docker-compose file, and
bump the version for a new release.