### PR TITLE
Move email over to the contrib namespace.

### DIFF
--- a/Dockerfile-django-py3
+++ b/Dockerfile-django-py3
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 RUN apt update
 RUN apt install entr --yes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The long term plan is to simplify this library as much as possible. This will be
 - [x] Deprecate all other methods on `EventClient`, except `email` related ones.
 - [x] Decouple `EventClient` from any particular backend to send events.
 - [x] Move over sending events through Django Rest Framework.
-- [ ] Move over sending specific `email` type of events.
+- [x] Move over sending specific `email` type of events.
 - [ ] Create a `celery` backend to stop placing things directly on rabbitmq, with sane defaults.
 - [ ] Major version change that removes deprecated methods and classes.
 

--- a/examples/django/example/settings.py
+++ b/examples/django/example/settings.py
@@ -193,3 +193,7 @@ JWT_AUTH = {
 }
 
 JSON_API_FORMAT_KEYS = 'camelize'
+
+# Used for sending emails
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+AWS_SECRET_KEY_ID = os.environ.get('AWS_SECRET_ACCESS_KEY')

--- a/zc_events/contrib/__init__.py
+++ b/zc_events/contrib/__init__.py
@@ -1,0 +1,1 @@
+from zc_events.contrib.email import send as send_email

--- a/zc_events/contrib/email.py
+++ b/zc_events/contrib/email.py
@@ -1,0 +1,54 @@
+import uuid
+import logging
+from zc_events.email import generate_email_data
+
+
+logger = logging.getLogger(__name__)
+
+
+def send(event_client, from_email=None, to=None, cc=None, bcc=None, reply_to=None, subject=None,
+         plaintext_body=None, html_body=None, headers=None, files=None, attachments=None,
+         user_id=None, resource_type=None, resource_id=None, unsubscribe_group=None,
+         is_transactional=False, wait_for_response=False):
+    """Send an email
+
+    Args:
+        event_client - an instatiated event client used for message passing.
+
+    Kwargs:
+        to - a list of email addresses to send to
+        from - a string that will be used in the "from" field
+        cc - a list of email addresses which will be copied on the communication
+        bcc - a list of email addresses that will be blind copied on the communication
+        reply_to - TBD
+        subject - The subject line of the email
+        plaintext_body - a plaintext email body
+        html_body - a html email body
+        user_id - TBD
+        headers - TBD
+        unsubscribe_group - TBD
+        attachments - TBD
+        files - TBD
+        is_transactional - bool to tell the email server if this is a transactional email (default False)
+        wait_for_response - bool to wait for a response or not (default False)
+    """
+    email_uuid = uuid.uuid4()
+    msg = '''MICROSERVICE_SEND_EMAIL: Upload email with UUID {}, to {}, from {},
+    with attachments {} and files {}'''
+    logger.info(msg.format(email_uuid, to, from_email, attachments, files))
+    event_data = generate_email_data(email_uuid,
+                                     from_email=from_email, to=to, cc=cc, bcc=bcc, reply_to=reply_to, subject=subject,
+                                     plaintext_body=plaintext_body, html_body=html_body, headers=headers, files=files,
+                                     attachments=attachments, user_id=user_id, resource_type=resource_type,
+                                     resource_id=resource_id, unsubscribe_group=unsubscribe_group,
+                                     is_transactional=is_transactional)
+    if wait_for_response:
+        func = event_client.post
+    else:
+        func = event_client.post_no_wait
+
+    returned = func('send_email', event_data)
+    logger.info('MICROSERVICE_SEND_EMAIL: Sent email with UUID {} and data {}'.format(
+        email_uuid, event_data
+    ))
+    return email_uuid, event_data, returned


### PR DESCRIPTION
In order to better seperate lower level `event_client` style calls with
what is a convienence layer built on top, we have chosen to move those
convienence functions to a `contrib` namespace. This should have several
advantages over the current implementation:

- Makes it clear to the developer that this is extra, and optional, functionality.
- Makes transport more agnostic and explicit.

Example usage would be:

```python
from zc_events.contrib import send_email
from myapp import event_client

to = ['someone@example.com']
from_email = 'sender@example.com'
subject = 'This is the subject.'
body = 'Here is the email body'

send_email(event_client, to=to, from_email=from_email, subject=subject,
           plaintext_body=body)
```