### PR TITLE
Upgrade to be more Python 3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
     ],
     install_requires=[
-        'boto3==1.4.7',
+        'boto3>=1.4.7',
         'celery>=3.1.10,<4.0.0',
         'inflection>=0.3.1,<0.4',
         'pika>=0.10.0,<0.11.0',

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.7-rc5',
+    version='0.3.7-rc6',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc5',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc6',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,84 @@
+from six import binary_type, text_type
+from unittest import TestCase
+from zc_events.utils import model_to_dict
+
+
+class ExampleModel(object):
+    def __init__(self):
+        self.control_attr = 'test'
+
+
+class ModelToDictTests(TestCase):
+
+    def dictify(self):
+        attr_dict = {x: x for x in ['test_attr', 'control_attr']}
+        return model_to_dict(self.test_model, attr_dict)
+
+    def setUp(self):
+        self.test_model = ExampleModel()
+
+    def test_control_attr(self):
+        self.test_model.test_attr = 'fdsa'
+        model_dict = self.dictify()
+        self.assertIn('control_attr', list(model_dict.keys()))
+        self.assertIn('test', list(model_dict.values()))
+
+    def test_instance__and_returned_attr_names(self):
+        self.test_model.instance_attr = 'foobar'
+        attr_dict = {'returned_attr': 'instance_attr', 'control_attr': 'control_attr'}
+        model_dict = model_to_dict(self.test_model, attr_dict)
+        expected_dict = {'returned_attr': 'foobar', 'control_attr': 'test'}
+        self.assertEqual(model_dict, expected_dict)
+
+    def test_none_attr(self):
+        self.test_model.test_attr = None
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': None, 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), type(None))
+
+    def test_int_attr(self):
+        self.test_model.test_attr = 123
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': 123, 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), int)
+
+    def test_float_attr(self):
+        self.test_model.test_attr = 123.456
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': 123.456, 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), float)
+
+    def test_bool_attr(self):
+        self.test_model.test_attr = False
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': False, 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), bool)
+
+        self.test_model.test_attr = True
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': True, 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), bool)
+
+    def test_bytes_attr(self):
+        self.test_model.test_attr = 'asdf'.encode('utf-8')
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': 'asdf'.encode('utf-8'), 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), binary_type)
+
+    def test_str_attr(self):
+        self.test_model.test_attr = text_type('asdf')
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': text_type('asdf'), 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), text_type)
+
+    def test_list_attr(self):
+        self.test_model.test_attr = [1, 'foo']
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': [1, 'foo'], 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), list)
+
+    def test_dict_attr(self):
+        self.test_model.test_attr = {'foo': 123}
+        model_dict = self.dictify()
+        self.assertEqual(model_dict, {'test_attr': {'foo': 123}, 'control_attr': 'test'})
+        self.assertEqual(type(model_dict['test_attr']), dict)

--- a/zc_events/utils.py
+++ b/zc_events/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import collections
+from six import text_type
 
 
 def _get_attr(model_instance, attr_name):
@@ -37,7 +38,7 @@ def model_to_dict(instance, included_attributes={}):
         if type(attr_value) in (datetime.date, datetime.datetime, datetime.time):
             attr_value = str(attr_value)
 
-        if type(attr_value) not in (type(None), int, int, float, bool, str, unicode, list, dict):
+        if type(attr_value) not in (type(None), int, int, float, bool, str, text_type, list, dict):
             raise TypeError('Unexpected value for {} attribute. I found {}'.format(attr_name, type(attr_value)))
 
         data.setdefault(name, attr_value)

--- a/zc_events/utils.py
+++ b/zc_events/utils.py
@@ -38,7 +38,7 @@ def model_to_dict(instance, included_attributes={}):
         if type(attr_value) in (datetime.date, datetime.datetime, datetime.time):
             attr_value = str(attr_value)
 
-        if type(attr_value) not in (type(None), int, int, float, bool, str, text_type, list, dict):
+        if type(attr_value) not in (type(None), int, float, bool, str, text_type, bytes, list, dict):
             raise TypeError('Unexpected value for {} attribute. I found {}'.format(attr_name, type(attr_value)))
 
         data.setdefault(name, attr_value)


### PR DESCRIPTION
Use `text_type` instead of `unicode` and upgrades `boto` to a py3 compatible version.