### PR TITLE
Handles view with pk kwarg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.7-rc8',
+    version='0.3.8',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.7-rc8',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.8',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -369,6 +369,8 @@ class EventClient(object):
         handler_kwargs = {}
         if view:
             handler = view.as_view()
+            if pk:
+                handler_kwargs['pk'] = pk
         elif pk:
             handler_kwargs['pk'] = pk
             if relationship:


### PR DESCRIPTION
When the event client handles a request that maps to a view (not a viewset), it should also pass along any relevant kwargs.

In this instance, an event that maps to a view with a `kwarg` of `pk` should pass that `kwarg` on to the view via the handler.

For example, for a request like `GET /special_view/1` that mapped to a view such as `class SpecialView(APIView)`, the gateway route `/special_view{/pk}` should pass that `pk` kwarg to the handler, which can call `SpecialView.get(request, *args, **kwargs)` with `kwargs = {'pk': 1}`.