### PR TITLE
DASH-4959, DASH-3367, DASH-2887: Add support for slack notifications, django and python upgrades

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.3.10',
+    version='0.4.0',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_events',
-    version='0.4.0',
+    version='0.4.1',
     description="Shared code for ZeroCater microservices events",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_events',
-    download_url='https://github.com/ZeroCater/zc_events/tarball/0.3.10',
+    download_url='https://github.com/ZeroCater/zc_events/tarball/0.4.1',
     license='MIT',
     packages=get_packages('zc_events'),
     classifiers=[
@@ -44,7 +44,7 @@ setup(
         'redis>=2.10.5,<=3.5.3',
 
         'ujson>=1.35,<1.36',
-        'zc_common>=0.4.1',
+        'zc_common @ git+https://github.com/ZeroCater/zc_common@ca62359f1afb29bdaede86c577e7130aca565613#egg=zc_common',
         'pyjwt>=1.4.0,<2.0.0',
         'six>=1.10.0'
     ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'redis>=2.10.5,<=3.5.3',
 
         'ujson>=1.35,<1.36',
-        'zc_common @ git+https://github.com/ZeroCater/zc_common@ca62359f1afb29bdaede86c577e7130aca565613#egg=zc_common',
+        'zc_common @ git+https://github.com/ZeroCater/zc_common@640291425a587e5cf972f4850df2199d16ac9cf8#egg=zc_common',
         'pyjwt>=1.4.0,<2.0.0',
         'six>=1.10.0'
     ]

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,14 @@ setup(
         'boto3>=1.4.7',
         'celery>=3.1.10',
         'inflection>=0.3.1,<0.4',
-        'pika>=0.10.0,<0.11.0',
-        'pika_pool>=0.1.3,<0.1.4',
-        'redis>=2.10.5,<2.11.0',
+        # These changes mirror the workaround we used to fix py-gateway builds
+        # https://github.com/ZeroCater/zc_events/compare/ctowstik/mp-962-pika-zc-events
+        # https://zerocater-eng.atlassian.net/browse/MP-962
+        # pika <= 0.11 cannot be used with Python 3.7+ due to `async` keyword being reserved
+        'pika>=0.10.0,<=0.13.1',
+        'pika-pool @ git+https://github.com/codytowstik/pika-pool@b4915988e5f34bbeaecbc21a42398b098b334aa2#egg=pika-pool', # noqa
+        'redis>=2.10.5,<=3.5.3',
+
         'ujson>=1.35,<1.36',
         'zc_common>=0.4.1',
         'pyjwt>=1.4.0,<2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         # https://zerocater-eng.atlassian.net/browse/MP-962
         # pika <= 0.11 cannot be used with Python 3.7+ due to `async` keyword being reserved
         'pika>=0.10.0,<=0.13.1',
-        'pika-pool @ git+https://github.com/codytowstik/pika-pool@b4915988e5f34bbeaecbc21a42398b098b334aa2#egg=pika-pool', # noqa
+        'pika-pool @ git+https://github.com/codytowstik/pika-pool@b4915988e5f34bbeaecbc21a42398b098b334aa2#egg=pika-pool',  # noqa
         'redis>=2.10.5,<=3.5.3',
 
         'ujson>=1.35,<1.36',

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -510,9 +510,9 @@ class EventClient(object):
 
         if logger:
             msg = (
-                f'MICROSERVICE_SEND_SLACK_NOTIFICATION: Send slack notification. '
-                f'User (multiuser_id: {canonical_user_id}), '
-                f'Type: ({notification_type}), Application ({application}), Data ({message_data})'
+                f'[MICROSERVICE_SEND_SLACK_NOTIFICATION] Send slack notification. '
+                f'User canonical_user_id={canonical_user_id}, '
+                f'notification_type={notification_type}, application={application}, data={message_data}'
             )
             logger.info(msg)
 

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -326,6 +326,10 @@ class EventClient(object):
         return self.emit_microservice_message(
             self.notifications_exchange, 'microservice.notification.push', event_type, *args, **kwargs)
 
+    def emit_microservice_slack_notification(self, event_type, *args, **kwargs):
+        return self.emit_microservice_message(
+            self.notifications_exchange, 'microservice.notification.slack', event_type, *args, **kwargs)
+
     def wait_for_response(self, response_key):
         response = self.redis_client.blpop(response_key, 60)
         return response
@@ -497,6 +501,25 @@ class EventClient(object):
             ))
 
         self.emit_microservice_email_notification('send_email', **event_data)
+
+    def send_slack_notification(self, *args, **kwargs):
+        slack_uuid = uuid.uuid4()
+
+        canonical_user_id = kwargs.get('canonical_user_id')
+        notification_type = kwargs.get('notification_type')
+        title = kwargs.get('title')
+        body = kwargs.get('body')
+        application = kwargs.get('application')
+        message_data = kwargs.get('data')
+
+        if logger:
+            msg = (
+                f'MICROSERVICE_SEND_SLACK_NOTIFICATION: Send slack notification with UUID {slack_uuid}, '
+                f'User (canonical_user_id: {canonical_user_id}), Title: ({title}), Body: ({body}),  '
+                f'Type: ({notification_type}) with Data ({message_data}) via Application ({application})'
+            )
+
+        self.emit_microservice_push_notification('send_slack_notification', **kwargs)
 
     def send_push_notification(self, *args, **kwargs):
         push_uuid = uuid.uuid4()

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -98,12 +98,13 @@ class EventClient(object):
             pika_params = pika.URLParameters(settings.BROKER_URL)
             pika_params.socket_timeout = 5
             self._pika_pool = pika_pool.QueuedPool(
+                # ccody - maybe we change these in tests?
                 create=lambda: pika.BlockingConnection(parameters=pika_params),
-                max_size=10,
-                max_overflow=10,
-                timeout=10,
-                recycle=3600,
-                stale=45,
+                max_size=20,
+                max_overflow=20,
+                timeout=20,
+                recycle=4800,
+                stale=90,
             )
         return self._pika_pool
 
@@ -277,7 +278,7 @@ class EventClient(object):
             'args': [event_type] + list(args),
             'kwargs': keyword_args
         }
-
+        # what is this even doing? this will only be correct in prod. .. it only declares
         event_queue_name = '{}-events'.format(settings.SERVICE_NAME)
         event_body = ujson.dumps(message)
 

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -518,6 +518,21 @@ class EventClient(object):
 
         self.emit_microservice_slack_notification('send_slack_notification', **kwargs)
 
+    def forward_slack_notification(self, *args, **kwargs):
+        canonical_user_id = kwargs.get('canonical_user_id')
+        notification_type = kwargs.get('notification_type')
+        message_data = kwargs.get('data')
+
+        if logger:
+            msg = (
+                f'[MICROSERVICE_SEND_SLACK_NOTIFICATION] Send slack notification. '
+                f'User canonical_user_id={canonical_user_id}, '
+                f'notification_type={notification_type}, data={message_data}'
+            )
+            logger.info(msg)
+
+        self.emit_microservice_slack_notification('forward_slack_notification', **kwargs)
+
     def send_push_notification(self, *args, **kwargs):
         push_uuid = uuid.uuid4()
 

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -100,13 +100,12 @@ class EventClient(object):
             pika_params = pika.URLParameters(settings.BROKER_URL)
             pika_params.socket_timeout = 5
             self._pika_pool = pika_pool.QueuedPool(
-                # ccody - maybe we change these in tests?
                 create=lambda: pika.BlockingConnection(parameters=pika_params),
-                max_size=20,
-                max_overflow=20,
-                timeout=20,
-                recycle=4800,
-                stale=90,
+                max_size=10,
+                max_overflow=10,
+                timeout=10,
+                recycle=3600,
+                stale=45,
             )
         return self._pika_pool
 
@@ -280,7 +279,6 @@ class EventClient(object):
             'args': [event_type] + list(args),
             'kwargs': keyword_args
         }
-        # what is this even doing? this will only be correct in prod. .. it only declares
         event_queue_name = '{}-events'.format(settings.SERVICE_NAME)
         event_body = ujson.dumps(message)
 

--- a/zc_events/client.py
+++ b/zc_events/client.py
@@ -503,23 +503,20 @@ class EventClient(object):
         self.emit_microservice_email_notification('send_email', **event_data)
 
     def send_slack_notification(self, *args, **kwargs):
-        slack_uuid = uuid.uuid4()
-
         canonical_user_id = kwargs.get('canonical_user_id')
         notification_type = kwargs.get('notification_type')
-        title = kwargs.get('title')
-        body = kwargs.get('body')
         application = kwargs.get('application')
         message_data = kwargs.get('data')
 
         if logger:
             msg = (
-                f'MICROSERVICE_SEND_SLACK_NOTIFICATION: Send slack notification with UUID {slack_uuid}, '
-                f'User (canonical_user_id: {canonical_user_id}), Title: ({title}), Body: ({body}),  '
-                f'Type: ({notification_type}) with Data ({message_data}) via Application ({application})'
+                f'MICROSERVICE_SEND_SLACK_NOTIFICATION: Send slack notification. '
+                f'User (multiuser_id: {canonical_user_id}), '
+                f'Type: ({notification_type}), Application ({application}), Data ({message_data})'
             )
+            logger.info(msg)
 
-        self.emit_microservice_push_notification('send_slack_notification', **kwargs)
+        self.emit_microservice_slack_notification('send_slack_notification', **kwargs)
 
     def send_push_notification(self, *args, **kwargs):
         push_uuid = uuid.uuid4()


### PR DESCRIPTION
## Summary
### Issue or Feature

Support Slack notification event.

### Description of Changes

exchange: `microservice.notification.slack`
event: `send_slack_notification`
- to be sent from `catering-core` and picked up by `microservice_event_listener` of `mp-email`


## Additional Information


## Checklist
- [x] Ticket number is referenced in PR title
- [x] All functional requirements are met
- [ ] Changes are unit tested
    - [ ] Branching paths
    - [ ] Edge cases
- [x] TODOs removed
- [x] Debug statements removed
- [x] Branch is up-to-date with target branch 
- [x] Redundant code is abstracted
- [x] Class, function, and variable names are descriptive